### PR TITLE
fix: add description of the app to index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Web site created using create-react-app" />
+    <meta name="description" content="Metroline is an Open Source Continuous Integration and Delivery Platform" />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">


### PR DESCRIPTION
remove the react app boilerplate and put in a real description.

the existing description messes with URL previews as per the attached screenshot.

![image](https://user-images.githubusercontent.com/60991921/97625984-0754f180-1a08-11eb-9407-963e297115b7.png)

Now it will help to better describe what the page is, vs. being a "create-react-app".