### PR TITLE
fix: font size reduction in pipeline consoles

### DIFF
--- a/src/components/pipelines/JobLogs.module.scss
+++ b/src/components/pipelines/JobLogs.module.scss
@@ -10,7 +10,7 @@
   font-family: 'Oxygen Mono', monospace;
   font-style: normal;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 13px;
   border-radius: 0 0 5px 5px;
   padding: 20px 30px;
   line-height: 130%;


### PR DESCRIPTION
The font size in the console is too big, reducing a value will make it look better.